### PR TITLE
handle EACCES in `open`

### DIFF
--- a/src/ourio/Uring.zig
+++ b/src/ourio/Uring.zig
@@ -441,6 +441,7 @@ pub fn reapCompletions(self: *Uring, rt: *io.Ring) anyerror!void {
                 .CANCELED => io.ResultError.Canceled,
                 .NOTDIR => posix.OpenError.NotDir,
                 .ISDIR => posix.OpenError.IsDir,
+                .ACCES => posix.OpenError.AccessDenied,
                 else => |e| unexpectedError(e),
             } },
 


### PR DESCRIPTION
If you want I can handle it for other syscalls too it's just that I need it for lsr because `lsr <directory i don't have access to>` just says "Unexpected"